### PR TITLE
frontend: rewrite relative paths in markdown

### DIFF
--- a/frontend/src/Components/File.elm
+++ b/frontend/src/Components/File.elm
@@ -5,12 +5,33 @@ import Html.Attributes as HA
 import Octicons
 
 
+{-| Options to configure how the file is rendered.
+
+  - `fileName` - The name of the file. This is displayed in the header.
+
+  - `contents` - The contents of the file.
+
+  - `class` - Extra classes to add to the file.
+
+  - `language` - The language of the file. The default is "markdown". Markdown
+    is rendered with marked. For other languages, the contents are highlighted
+    with highlight.js.
+
+  - `copyableContents` - Whether to enable the copy button and what to copy into the clipboard.
+
+  - `baseUrl` - The base URL to use when rewriting any relative URLS in the file.
+
+  - `rawBaseUrl` - The base URL to use when rewriting any image URLS in the file.
+
+-}
 type alias Options =
     { fileName : String
     , contents : String
     , class_ : String
     , language : String
     , copyableContents : Maybe String
+    , baseUrl : String
+    , rawBaseUrl : String
     }
 
 
@@ -21,6 +42,8 @@ defaultOptions =
     , class_ = ""
     , language = "markdown"
     , copyableContents = Nothing
+    , baseUrl = ""
+    , rawBaseUrl = ""
     }
 
 
@@ -42,6 +65,16 @@ class value options =
 language : String -> Options -> Options
 language value options =
     { options | language = value }
+
+
+baseUrl : String -> Options -> Options
+baseUrl value options =
+    { options | baseUrl = value }
+
+
+rawBaseUrl : String -> Options -> Options
+rawBaseUrl value options =
+    { options | rawBaseUrl = value }
 
 
 setCopyableContents : Maybe String -> Options -> Options
@@ -79,6 +112,8 @@ view options =
             [ HA.class <| String.join " " [ "px-8 py-8 overflow-x-scroll", options.class_ ]
             , HA.attribute "code" options.contents
             , HA.attribute "language" options.language
+            , HA.attribute "baseUrl" options.baseUrl
+            , HA.attribute "rawBaseUrl" options.rawBaseUrl
             ]
             []
         ]

--- a/frontend/src/Pages/Flake/Github/Org_/Repo_/Version_.elm
+++ b/frontend/src/Pages/Flake/Github/Org_/Repo_/Version_.elm
@@ -192,10 +192,23 @@ viewRelease model releases release =
                 ]
             , p [ class "mt-3 text-lg" ] [ text release.description ]
             ]
-        , File.defaultOptions
+        , let
+            baseUrl =
+                "https://github.com/" ++ release.owner ++ "/" ++ release.repo
+
+            revision =
+                if release.commit == "" then
+                    "HEAD"
+
+                else
+                    release.commit
+          in
+          File.defaultOptions
             |> File.fileName "README"
             |> File.class "markdown-body"
             |> File.contents release.readme
+            |> File.baseUrl (baseUrl ++ "/blob/" ++ revision ++ "/")
+            |> File.rawBaseUrl (baseUrl ++ "/raw/" ++ revision ++ "/")
             |> File.view
         ]
 


### PR DESCRIPTION
Adds a DOMPurify hook to rewrite any relative image and link paths.

Images are redirected to `https://github.com/OWNER/REPO/raw/REVISION/...`
Links are redirected to `https://github.com/OWNER/REPO/blob/REVISION/...`

The [marked-base-url](https://github.com/markedjs/marked-base-url) plugin works well for markdown, but doesn't handle HTML inside markdown, which a lot of GitHub READMEs have.

Resolves #14.