### PR TITLE
Add support for non-tagged publishing

### DIFF
--- a/backend/flakestry/api/publish.py
+++ b/backend/flakestry/api/publish.py
@@ -59,7 +59,10 @@ def publish(
     elif publish.version:
         ref = f"refs/tags/{publish.version}"
     else:
-        ref = "HEAD"
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"message": 'Neither "ref" nor "version" were provided'},
+        )
 
     # Get info on the commit to be published
     commit_response = requests.get(

--- a/backend/flakestry/api/publish.py
+++ b/backend/flakestry/api/publish.py
@@ -75,12 +75,17 @@ def publish(
     commit_date = commit_json["commit"]["committer"]["date"]
 
     # Validate & parse version
+    datetime = re.sub(r"[^0-9]", "", commit_date)
     if publish.version:
-        given_version = publish.version
+        given_version = publish.version.format(
+            datetime=datetime,
+            date=datetime[:8],
+            time=datetime[8:],
+        )
     elif publish.ref and publish.ref.startswith("refs/tags/"):
         given_version = publish.ref.removeprefix("refs/tags/")
     else:
-        given_version = f"v0.1.{re.sub(r'[^0-9]', '', commit_date)}"
+        given_version = f"v0.1.{datetime}"
 
     version_regex = r"^v?([0-9]+\.[0-9]+\.?[0-9]*$)"
     version = re.search(version_regex, given_version)

--- a/frontend/src/Pages/Publish.elm
+++ b/frontend/src/Pages/Publish.elm
@@ -15,16 +15,33 @@ page =
             [ Flakestry.Layout.viewNav
             , main_ []
                 [ div
-                    [ class "container px-4 max-w-5xl" ]
+                    [ class "container px-4 py-24 max-w-5xl" ]
                     [ h1
-                        [ class "py-24 text-4xl font-semibold md:text-center"
-                        ]
+                        [ class "text-4xl font-semibold md:text-center" ]
+                        [ text "Publish your Flake" ]
+                    , p
+                        [ class "mt-6 text-l text-slate-600" ]
+                        [ text """
+                            Currently it's possible to publish flakes via GitHub actions.
+                            Here're a few examples on how to make use of it to release your very own flakes.
+                        """ ]
+                    , h2
+                        [ class "max-w-3xl flex items-center pt-12 text-2xl text-slate-900 font-semibold py-4" ]
                         [ text "Publish your Flake for each tag" ]
                     , File.defaultOptions
                         |> File.fileName ".github/workflows/publish.yaml"
                         |> File.language "yaml"
-                        |> File.contents publishFlakeYaml
-                        |> File.setCopyableContents (Just publishFlakeYaml)
+                        |> File.contents publishTaggedFlakeYaml
+                        |> File.setCopyableContents (Just publishTaggedFlakeYaml)
+                        |> File.view
+                    , h2
+                        [ class "max-w-3xl flex items-center pt-12 text-2xl text-slate-900 font-semibold py-4" ]
+                        [ text "Publish your Flake for each push to the default branch" ]
+                    , File.defaultOptions
+                        |> File.fileName ".github/workflows/publish.yaml"
+                        |> File.language "yaml"
+                        |> File.contents publishRollingFlakeYaml
+                        |> File.setCopyableContents (Just publishRollingFlakeYaml)
                         |> File.view
                     ]
                 ]
@@ -33,14 +50,14 @@ page =
     }
 
 
-publishFlakeYaml : String
-publishFlakeYaml =
+publishTaggedFlakeYaml : String
+publishTaggedFlakeYaml =
     """name: "Publish a flake to flakestry"
 on:
     push:
         tags:
-        - "v?[0-9]+.[0-9]+.[0-9]+"
-        - "v?[0-9]+.[0-9]+"
+            - "v?[0-9]+.[0-9]+.[0-9]+"
+            - "v?[0-9]+.[0-9]+"
     workflow_dispatch:
         inputs:
             tag:
@@ -57,4 +74,30 @@ jobs:
             - uses: flakestry/flakestry-publish@main
               with:
                 version: "${{ inputs.tag || github.ref_name }}"
+"""
+
+
+publishRollingFlakeYaml : String
+publishRollingFlakeYaml =
+    """name: "Publish a flake to flakestry"
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+        inputs:
+            ref:
+                description: "The existing reference to publish"
+                type: "string"
+                required: true
+jobs:
+    publish-flake:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: "write"
+            contents: "read"
+        steps:
+            - uses: flakestry/flakestry-publish@main
+              with:
+                ref: "${{ inputs.ref || github.ref }}"
 """


### PR DESCRIPTION
Modifies the publish API endpoint so that it does not assume that the release being created is using a tag. For this, it adds a `ref` input that points to the commit to be released. Should be backwards compatible since if `ref` is not provided it defaults to `f"refs/tags/{version}"`.

To make this work, had to change the order in which some operations were done. And modified a 400 code to 409 since it was more appropriate and it allows the caller to know why it failed and potentially ignore the error (see https://github.com/flakestry/flakestry-publish/pull/2).

Finally, since I could not for the life of me create an `OIDC JWT ID` for testing, I only tested the API call to GitHub separately and could not test the endpoint as a whole.

Closes #26