### PR TITLE
Fix status badge

### DIFF
--- a/frontend/src/Pages/Flake/Github/Org_/Repo_/Version_.elm
+++ b/frontend/src/Pages/Flake/Github/Org_/Repo_/Version_.elm
@@ -348,7 +348,7 @@ viewOutputs model flakeRelease =
         (\release ->
             let
                 badgeMarkdown =
-                    "[![flakestry.dev](https://flakestry.dev" ++ Route.Path.toString model.route ++ ")](https://flakestry.dev" ++ badgeImage ++ ")"
+                    "[![flakestry.dev](https://flakestry.dev" ++ badgeImage ++ ")](https://flakestry.dev" ++ Route.Path.toString model.route ++ ")"
 
                 badgeImage =
                     "/api/badge/flake/github/" ++ model.org ++ "/" ++ model.repo


### PR DESCRIPTION
The status badge provided by [flakestry.dev](https://flakestry.dev/flake/github/sestrella/asdf2nix/) appears to be broken:

[![flakestry.dev](https://flakestry.dev/flake/github/sestrella/asdf2nix/)](https://flakestry.dev/api/badge/flake/github/sestrella/asdf2nix)

Swapping the status badge's components appears to work:

[![flakestry.dev](https://flakestry.dev/api/badge/flake/github/sestrella/asdf2nix)](https://flakestry.dev/flake/github/sestrella/asdf2nix/)

Fixes #40 