### PR TITLE
devenv: inject <noscript-tag> after build

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -22,6 +22,7 @@ let
     generate-elm-api
     pushd frontend
     elm-land build
+    inject-noscript-tag
     popd
     devenv container ${env} --copy
     flyctl deploy --vm-memory 1024 -a flakestry-${env} \
@@ -121,6 +122,10 @@ in
     # Replace cross-origin requests with requests to the same host
     sed -i "s#Url.Builder.crossOrigin req.basePath req.pathParams#Url.Builder.absolute (\"api\" :: req.pathParams)#g" \
       ${config.devenv.root}/frontend/generated-api/src/Api.elm
+  '';
+  scripts.inject-noscript-tag.exec = ''
+    sed -i "s|.*placeholder-no-script-tag.*|<noscript><div>Cannot use Flaskestry.dev without javascript</div></noscript>|" \
+      ${config.devenv.root}/frontend/dist/index.html
   '';
 
   processes = {

--- a/frontend/elm-land.json
+++ b/frontend/elm-land.json
@@ -19,7 +19,8 @@
       "link": [
         { "rel": "stylesheet", "href": "https://rsms.me/inter/inter.css" },
         { "rel": "stylesheet", "href": "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css"},
-        { "rel": "icon", "type": "image/x-icon", "href": "/logo.png" }
+        { "rel": "icon", "type": "image/x-icon", "href": "/logo.png" },
+        { "rel": "placeholder-no-script-tag", "href": "#" }
       ],
       "script": []
     },


### PR DESCRIPTION
Informs users that they need to whitelist the site to view the SPA. Couldn't find a way to do within elm.

closes #27 